### PR TITLE
pebble-tool: 4.6rc1 -> 4.6rc2, pebbleEnv: add cloudPebble option

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Development shells can be configured by specifying the following arguments to
 - `devServerIP`: The default development server IP. You can find this in the
   Pebble app.
 - `emulatorTarget`: The default target to start the Pebble emulator for.
+- `cloudPebble`: Whether to connect via a CloudPebble connection. Requires
+  logging into Rebble via `pebble login`.
 - `nativeBuildInputs`: Any extra tools to use during development.
 
 ### App Store Builds

--- a/buildTools/pebbleEnv.nix
+++ b/buildTools/pebbleEnv.nix
@@ -4,6 +4,8 @@
 
 , emulatorTarget ? null
 
+, cloudPebble ? false
+
 , nativeBuildInputs ? [ ] }@attrs:
 
 let
@@ -15,6 +17,7 @@ let
   rest = builtins.removeAttrs attrs [
     "devServerIP"
     "emulatorTarget"
+    "cloudPebble"
     "nativeBuildInputs"
   ];
 in pkgs.callPackage ({ gcc8Stdenv, nodejs }:
@@ -27,6 +30,7 @@ in pkgs.callPackage ({ gcc8Stdenv, nodejs }:
 
     PEBBLE_PHONE = devServerIP;
     PEBBLE_EMULATOR = emulatorTarget;
+    PEBBLE_CLOUDPEBBLE = if cloudPebble then "1" else null;
 
     nophase = ''
       echo This derivation is a Pebble development shell, and not meant to be built.

--- a/derivations/pebble-tool/default.nix
+++ b/derivations/pebble-tool/default.nix
@@ -10,13 +10,13 @@ let
   rpath = lib.makeLibraryPath [ freetype stdenv.cc.cc.lib zlib ];
 in python2Packages.buildPythonPackage rec {
   pname = "pebble-tool";
-  version = "4.6rc1";
+  version = "4.6rc2";
 
   src = fetchFromGitHub {
     owner = "pebble-dev";
     repo = "pebble-tool";
-    rev = "f1b4d08f5b0d99ac50407691065766ce17d2cdb8";
-    sha256 = "1hxmk6lhrgrhcikp4zy44mj80fxbqd53wykya97r4ikgbvzyanm6";
+    rev = "92561f5c075fe5c812b69409ef338a3548928472";
+    sha256 = "1070jkkzg9ba1vp4gq3yfxw456gzajw37kidh1qiv1wawb655j9q";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
4.6rc2 adds support for Rebble services, allowing the use of CloudPebble connections.