### PR TITLE
pebble-qemu: force use of https://github.com rather than the git protocol

### DIFF
--- a/derivations/pebble-qemu/default.nix
+++ b/derivations/pebble-qemu/default.nix
@@ -16,13 +16,19 @@ in stdenv.mkDerivation rec {
   name = "pebble-qemu";
   version = "2.5.0-pebble4";
 
-  src = fetchFromGitHub {
+  src = (fetchFromGitHub {
     owner = "pebble";
     repo = "qemu";
     rev = "v${version}";
     sha256 = "1r7692hhd70nrbscznc33vi3ndv51sdlg9vc0ay4h4s1xrqv5d0g";
     fetchSubmodules = true;
-  };
+  }).overrideAttrs (attrs: {
+    postHook = ''
+      # pebble/qemu references a git://github.com URL, which won't work as of 2022.
+      export HOME=$PWD
+      git config --global url.https://github.com/.insteadOf git://github.com/
+    '';
+  });
 
   nativeBuildInputs = [ autoconf automake libtool perl pkgconfig python2 ];
 


### PR DESCRIPTION
...which has since been turned off.