### PR TITLE
Draft: fix buildPebbleApp, use new SDK, test reverse dependencies compilation

### DIFF
--- a/.github/workflows/buildAndCache.yml
+++ b/.github/workflows/buildAndCache.yml
@@ -33,3 +33,29 @@ jobs:
 
     - name: Build pebbleEnv
       run: nix shell -f default.nix pebbleEnv --command sh -c "echo OK"
+
+    - name: 'Build reverse dependency: no-time-for-this'
+      run: |
+        REPO=https://github.com/nilp0inter/no-time-for-this
+        REV=45fa8581402955adc2b626a3f6509d8fa5701bb9
+        git clone --depth=1 --revision "$REV" "$REPO" revdeps/no-time-for-this
+        RDEP=path:revdeps/no-time-for-this
+        nix build -L "$RDEP" --override-input pebble "$GITHUB_WORKSPACE"
+
+    - name: 'Build reverse dependency: skunk'
+      run: |
+        REPO=https://github.com/unlobito/skunk
+        REV=dcd7db99a408b5de2d988e6729ce0daaa70f6137
+        git clone --depth=1 --revision "$REV" "$REPO" revdeps/skunk
+        RDEP=revdeps/skunk/default.nix
+        DIR=$GITHUB_WORKSPACE
+        nix build -L --impure --expr "import $RDEP { pebbleDotNixSrc = $DIR; }"
+
+    - name: 'Build reverse dependency: kijete'
+      run: |
+        REPO=https://github.com/yellowsink/kijete
+        REV=4818aaf57add82666496fb56de37574cf88cdc66
+        git clone --depth=1 --revision "$REV" "$REPO" revdeps/kijete
+        RDEP=revdeps/kijete/default.nix
+        DIR=$GITHUB_WORKSPACE
+        nix build -L --impure --expr "import $RDEP { pebbleDotNixSrc = $DIR; }"

--- a/buildTools/buildPebbleApp.nix
+++ b/buildTools/buildPebbleApp.nix
@@ -156,6 +156,9 @@ pkgsCross.gccStdenv.mkDerivation (
         ln -s ${nodeEnv}/lib/node_modules $SDK_ROOT/node_modules
 
         chmod -R u+w $HOME
+
+        # Use sandbox-writable path for pebble-tool's SDK symlink
+        export PEBBLE_SDK=$TMPDIR/pebble-sdk
       ''
       + postUnpack;
 

--- a/buildTools/buildPebbleApp.nix
+++ b/buildTools/buildPebbleApp.nix
@@ -2,7 +2,6 @@
   pkgs,
   nixpkgs,
   pebble-tool,
-  python-libs,
   system,
 }:
 
@@ -32,17 +31,18 @@ let
   };
 
   nodeEnv = (pkgs.callPackage ./nodeEnv { }).nodeDependencies;
-  pythonEnv = pkgs.python2.withPackages (
-    ps: with python-libs; [
-      ps.freetype-py
+  pythonEnv = pkgs.python3.withPackages (
+    ps: with ps; [
+      freetype-py
       sh
       pypng
     ]
   );
 
   pebble-sdk = pkgs.fetchzip {
-    url = "https://binaries.rebble.io/sdk-core/release/sdk-core-4.3.tar.bz2";
-    sha256 = "0p6x76rq5v9rb3j2fjdz1s2553n1yf5v2yhzxxp7g5220hmsk40j";
+    url = "https://sdk.core.store/releases/4.9.169/sdk-core.tar.gz";
+    sha256 = "sha256-y6xlDdKdMgIQS2rKbJaH5GjV95U76ISZetNA0RdXL0E=";
+    stripRoot = false;
   };
 
   stringNotEmpty = str: builtins.isString str && str != "";
@@ -148,22 +148,23 @@ pkgsCross.gccStdenv.mkDerivation (
       ''
         # Setup Pebble SDK
         export HOME=`pwd`/home-dir
-        SDK_ROOT=$HOME/.pebble-sdk/SDKs/4.3
+        SDK_DIR=$HOME/.pebble-sdk/SDKs
+        SDK_ROOT=$SDK_DIR/4.9.169
         mkdir -p $SDK_ROOT/sdk-core
-        cp -r ${pebble-sdk}/* $SDK_ROOT/sdk-core
-        ln -s $SDK_ROOT $SDK_ROOT/../current
-        ln -s ${pythonEnv} $SDK_ROOT/.env
+        cp -r ${pebble-sdk}/sdk-core $SDK_ROOT/
+        ln -s $SDK_ROOT $SDK_DIR/current
+        ln -s ${pythonEnv} $SDK_ROOT/.venv
         ln -s ${nodeEnv}/lib/node_modules $SDK_ROOT/node_modules
 
         chmod -R u+w $HOME
 
-        # Use sandbox-writable path for pebble-tool's SDK symlink
-        export PEBBLE_SDK=$TMPDIR/pebble-sdk
+        # Point pebble-tool at our SDK location; tmp link uses $TMPDIR
+        export PEBBLE_SDK=$HOME/.pebble-sdk
       ''
       + postUnpack;
 
     CFLAGS =
-      "-Wno-error=builtin-macro-redefined -Wno-error=builtin-declaration-mismatch -include sys/types.h "
+      "-Wno-error=builtin-macro-redefined -Wno-error=builtin-declaration-mismatch"
       + CFLAGS;
 
     buildPhase = ''

--- a/derivations/pebble-tool.nix
+++ b/derivations/pebble-tool.nix
@@ -43,6 +43,15 @@ python3Packages.buildPythonPackage rec {
     hash = "sha256-quBDT7Sh14v7N47H1EVsvELT3Kb7Oo9CkKx/OfvOkFs=";
   };
 
+  postPatch = ''
+    substituteInPlace pebble_tool/sdk/__init__.py --replace \
+      'tmp_link = "/var/tmp/pebble-sdk"' \
+      'tmp_link = os.path.join(os.environ.get("TMPDIR", "/tmp"), "pebble-sdk")'
+    substituteInPlace pebble_tool/util/__init__.py --replace \
+      'dir = os.path.expanduser("~/.pebble-sdk")' \
+      'dir = os.environ.get("PEBBLE_SDK", os.path.expanduser("~/.pebble-sdk"))'
+  '';
+
   nativeBuildInputs = [ makeWrapper ];
 
   buildInputs = [ nodejs ];

--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
         system: pkgs:
         import ./buildTools/buildPebbleApp.nix {
           inherit pkgs nixpkgs system;
-          pebble-tool = packages.pebble-tool;
+          inherit (pkgs) pebble-tool;
           python-libs = pkgs.callPackage ./derivations/pebble-tool/python-libs.nix { };
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,6 @@
         import ./buildTools/buildPebbleApp.nix {
           inherit pkgs nixpkgs system;
           inherit (pkgs) pebble-tool;
-          python-libs = pkgs.callPackage ./derivations/pebble-tool/python-libs.nix { };
         }
       );
 


### PR DESCRIPTION
This currently fails in CI with

```
error: hash mismatch in fixed-output derivation '/nix/store/9kirksnyvp4p4khsy88q5nbaykaicll5-stpyv8-13.1.201.22-cp312-cp312-manylinux_2_31_x86_64.whl.drv':
           likely URL: https://files.pythonhosted.org/packages/cp312/s/stpyv8/stpyv8-13.1.201.22-cp312-cp312-manylinux_2_31_x86_64.whl
            specified: sha256-g0uXYbt/SdqLiHhHx2R0laLPbEX2niEkrg4/AkSTvBU=
                  got: sha256-wkqkIVxk231n/GxCwNdzHKvPMAWWv5yCaudPQm/jt3E=
        expected path: /nix/store/92jsnc2aknw8sm6kx60dl7s7mbbqhfaw-stpyv8-13.1.201.22-cp312-cp312-manylinux_2_31_x86_64.whl
             got path: /nix/store/hayxzqiwa72ci9kqazy2lxhwjpksz5s6-stpyv8-13.1.201.22-cp312-cp312-manylinux_2_31_x86_64.whl
```

for reasons that evade me.

I don't insist things should be done this way, treat it more like a list of things that I think should be done for others to use your flake and feel safe doing it: feel free to cherry-pick, amend, etc.